### PR TITLE
fix(tools): Prevent dragonfly.logrotate to stop logrotate service

### DIFF
--- a/tools/packaging/debian/dragonfly.logrotate
+++ b/tools/packaging/debian/dragonfly.logrotate
@@ -15,7 +15,7 @@
         prerotate
                 if lsof -t $1 > /dev/null; then
                 # file is open. Skipping rotation."
-                exit 1
+                exit 0
                 fi
         endscript
 


### PR DESCRIPTION
If multiple logs are being rotated and one of them fails (due to exit 1), the other logs that follow won't be rotated either, unless logrotate is run again.

If you want to prevent the rotation of a specific log file and not affect the rest of the logs, you'll want to handle the condition properly to ensure that logrotate doesn't abort due to the failure of the prerotate script.

To prevent the rotation of a specific log file without causing issues for other logs, you can use exit 0 to prevent rotation cleanly or design your prerotate script to handle conditions carefully.